### PR TITLE
Gof trt boxplot fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cqtkit
 Title: Comprehensive C-QT Analysis From Data to Deliverables
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Matt", "Smith", , "matthews@a2-ai.com", role = c("aut", "cre")),
     person("Devin", "Pastoor", , "devin@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # cqtkit 1.0.1
 ### Fixed
-- Exposed the intended optional `legend_location` argument in `gof_residuals_trt_boxplots()`.
+* Exposed the intended optional `legend_location` argument in `gof_residuals_trt_boxplots()`.
 
 # cqtkit 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# cqtkit 1.0.1
+
 # cqtkit 1.0.0
 
 * Initial public release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # cqtkit 1.0.1
+### Fixed
+- Exposed the intended optional `legend_location` argument in `gof_residuals_trt_boxplots()`.
 
 # cqtkit 1.0.0
 

--- a/R/gof.R
+++ b/R/gof.R
@@ -688,6 +688,7 @@ gof_residuals_time_boxplots <- function(
 #' @param ntime_col An unquoted column name for nominal time since dose
 #' @param trt_col An unquoted column name for treatment group"
 #' @param residual_references Numeric vector of reference residual lines to add, default -2 and 2
+#' @param legend_location String for legend position (top, bottom, left, right)
 #' @param style A named list of arguments passed to style_plot()
 #'
 #' @return a ggarrange plot
@@ -715,11 +716,14 @@ gof_residuals_trt_boxplots <- function(
   ntime_col,
   trt_col = NULL,
   residual_references = c(-2, 2),
+  legend_location = c("top", "bottom", "left", "right", "none"),
   style = list()
 ) {
   checkmate::assertDataFrame(data)
   checkmate::assert(checkmate::check_class(fit, "lme"))
   checkmate::assert_numeric(residual_references, null.ok = TRUE)
+
+  legend_location <- match.arg(legend_location)
 
   dv <- rlang::enquo(dv_col)
   conc <- rlang::enquo(conc_col)
@@ -772,10 +776,13 @@ gof_residuals_trt_boxplots <- function(
   trt_plot <- ggpubr::ggarrange(
     plotlist = trtg_plots,
     ncol = 1,
-    common.legend = TRUE
+    common.legend = TRUE,
+    legend = legend_location
   )
-  if (!is.null(style$title))
+
+  if (!is.null(style$title)) {
     trt_plot <- ggpubr::annotate_figure(trt_plot, top = style$title)
+  }
 
   return(trt_plot)
 }

--- a/man/gof_residuals_trt_boxplots.Rd
+++ b/man/gof_residuals_trt_boxplots.Rd
@@ -12,6 +12,7 @@ gof_residuals_trt_boxplots(
   ntime_col,
   trt_col = NULL,
   residual_references = c(-2, 2),
+  legend_location = c("top", "bottom", "left", "right", "none"),
   style = list()
 )
 }
@@ -29,6 +30,8 @@ gof_residuals_trt_boxplots(
 \item{trt_col}{An unquoted column name for treatment group"}
 
 \item{residual_references}{Numeric vector of reference residual lines to add, default -2 and 2}
+
+\item{legend_location}{String for legend position (top, bottom, left, right)}
 
 \item{style}{A named list of arguments passed to style_plot()}
 }


### PR DESCRIPTION
exposed `legend_location` in `gof_residuals_trt_boxplots`

<img width="793" height="720" alt="image" src="https://github.com/user-attachments/assets/d3ca802f-30e8-4bff-adbf-3553f5a16898" />
