### PR TITLE
duplicate conc values can occur via cmaxes, which causes error in pre…

### DIFF
--- a/R/compute.R
+++ b/R/compute.R
@@ -1385,7 +1385,7 @@ compute_exposure_predictions <- function(
 
   if (!rlang::is_empty(cmaxes)) {
     new_conc <- c(prediction_df$conc, cmaxes)
-    prediction_df <- tibble::tibble(conc = sort(new_conc))
+    prediction_df <- tibble::tibble(conc = sort(unique(new_conc)))
   }
 
   ########## SHOULD THIS BE ITS OWN FUNCTION? ############

--- a/tests/testthat/test-compute_exposure_predictions.R
+++ b/tests/testthat/test-compute_exposure_predictions.R
@@ -45,7 +45,7 @@ test_that('compute_exposure_predictions does not add non-unique conc values with
     TRTG,
     TAFD,
     method = "ML",
-    remove_conc_iiv = FALSE
+    remove_conc_iiv = TRUE
   )
 
   expo_pred <- compute_exposure_predictions(

--- a/tests/testthat/test-compute_exposure_predictions.R
+++ b/tests/testthat/test-compute_exposure_predictions.R
@@ -32,3 +32,42 @@ test_that('compute_exposure_predictions runs fine for good model and full data',
     )
   )
 })
+
+
+test_that('compute_exposure_predictions does not add non-unique conc values with cmaxes', {
+  data_proc <- preprocess(cqtkit_data_dofetilide)
+  mod <- fit_prespecified_model(
+    data_proc,
+    deltaQTCF,
+    ID,
+    CONC,
+    deltaQTCFBL,
+    TRTG,
+    TAFD,
+    method = "ML",
+    remove_conc_iiv = FALSE
+  )
+
+  expo_pred <- compute_exposure_predictions(
+    data_proc,
+    mod,
+    CONC,
+    treatment_predictors = list(
+      CONC = 10,
+      deltaQTCFBL = 0,
+      TRTG = "Dofetilide",
+      TAFD = "1 HR"
+    ),
+    control_predictors = list(
+      CONC = 0,
+      deltaQTCFBL = 0,
+      TRTG = "Placebo",
+      TAFD = "1 HR"
+    ),
+    cmaxes = c(100, 200, 300)
+  )
+
+  expect_true(
+    expo_pred$conc |> length() == expo_pred$conc |> unique() |> length()
+  )
+})


### PR DESCRIPTION
…dict_with_exposure_plot. adding failing test showing conc column is not unique.